### PR TITLE
Restore SciPy-based A/A test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+.env
+.venv
+.envrc
+.ipynb_checkpoints/
+.DS_Store
+# Data artifacts
+/data/
+!data/README.md
+
+# Local python packaging
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# ab-testing-example
+# AB Testing Example
+
+This repository demonstrates a minimal workflow for running an A/A test on a sample of the
+[Criteo Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge)
+dataset. The example focuses on two utilities:
+
+1. `scripts/download_criteo_sample.py` downloads a small, publicly hosted sample of the dataset.
+2. `run_aa_test.py` performs a two-tailed t-test to validate that randomly assigned buckets have
+   no statistically significant difference in click-through rate.
+
+## Getting started
+
+Create and activate a virtual environment, then install the project in editable mode. The
+repository depends on [SciPy](https://scipy.org/) for the statistical test, so `pip` will fetch it
+as part of the installation:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Downloading the sample dataset
+
+Use the download helper to fetch the 10k row sample provided by the RecoHut project. The command
+below stores the file under `data/raw/criteo_sample.csv` (which is ignored by git):
+
+```bash
+python scripts/download_criteo_sample.py
+```
+
+If the file already exists you can supply `--overwrite` to refresh it. A different source URL can be
+provided with `--url` when needed.
+
+## Running the A/A test
+
+Once you have a dataset available, run the A/A test script. The following command loads the
+downloaded sample and splits the observations into equal-sized buckets:
+
+```bash
+python run_aa_test.py --data-path data/raw/criteo_sample.csv
+```
+
+If you stored the sample under the default location you can omit `--data-path` entirely. Supply
+`--delimiter` if your dataset uses a separator other than a comma, and `--has-header` when the
+metric column is identified by name.
+
+The script prints the mean click-through rate for both buckets, their difference, and the p-value of
+a standard two-sample t-test computed via `scipy.stats.ttest_ind`. In a successful A/A test you
+should expect a high p-value and a small difference between the two groups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "ab-testing-example"
+version = "0.1.0"
+description = "Simple A/A testing example on a sample of the Criteo click dataset."
+authors = [{name = "Example Author"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "scipy>=1.8",
+]
+
+[tool.ruff]
+line-length = 100

--- a/run_aa_test.py
+++ b/run_aa_test.py
@@ -1,0 +1,161 @@
+"""Run a simple A/A test using a two-tailed independent t-test from SciPy."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import random
+import statistics
+from dataclasses import dataclass
+from typing import List, Optional
+
+from scipy import stats
+
+
+@dataclass
+class AaTestResult:
+    control_mean: float
+    treatment_mean: float
+    difference: float
+    p_value: float
+    control_size: int
+    treatment_size: int
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-path",
+        type=pathlib.Path,
+        default=pathlib.Path("data/raw/criteo_sample.csv"),
+        help="Path to the dataset file (comma-separated by default).",
+    )
+    parser.add_argument(
+        "--metric-column",
+        default="0",
+        help=(
+            "Column containing the binary click label. Provide either a zero-based index "
+            "or a column name if the file has headers."
+        ),
+    )
+    parser.add_argument(
+        "--delimiter",
+        default=",",
+        help="Field delimiter used in the dataset (default: comma).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed used when assigning samples to the two buckets.",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.5,
+        help="Proportion of observations assigned to the treatment bucket (default: 0.5).",
+    )
+    parser.add_argument(
+        "--has-header",
+        action="store_true",
+        help="Treat the first row of the file as a header row.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_metric(
+    data_path: pathlib.Path,
+    metric_column: str,
+    delimiter: str = ",",
+    has_header: bool = False,
+) -> List[float]:
+    metric_index: Optional[int] = None
+    column_name: Optional[str] = None
+
+    if metric_column.isdigit():
+        metric_index = int(metric_column)
+    else:
+        column_name = metric_column
+
+    values: List[float] = []
+    with data_path.open("r", newline="") as csvfile:
+        reader = csv.reader(csvfile, delimiter=delimiter)
+        if has_header:
+            header = next(reader, None)
+            if header is None:
+                return values
+            if column_name is not None:
+                try:
+                    metric_index = header.index(column_name)
+                except ValueError as exc:  # pragma: no cover - defensive
+                    raise ValueError(f"Column '{column_name}' not found in header") from exc
+        if metric_index is None:
+            raise ValueError(
+                "Metric column must be a zero-based index unless --has-header is provided with a valid name."
+            )
+        for row in reader:
+            if not row:
+                continue
+            try:
+                values.append(float(row[metric_index]))
+            except (IndexError, ValueError):
+                continue
+    return values
+
+
+def run_aa_test(metric: List[float], seed: int = 42, test_size: float = 0.5) -> AaTestResult:
+    if not 0.0 < test_size < 1.0:
+        raise ValueError("test_size must be between 0 and 1")
+
+    rng = random.Random(seed)
+    treatment: List[float] = []
+    control: List[float] = []
+    for value in metric:
+        if rng.random() < test_size:
+            treatment.append(value)
+        else:
+            control.append(value)
+
+    if len(control) < 2 or len(treatment) < 2:
+        raise ValueError("Both groups must contain at least two observations.")
+
+    control_mean = statistics.fmean(control)
+    treatment_mean = statistics.fmean(treatment)
+    difference = treatment_mean - control_mean
+
+    _, p_value = stats.ttest_ind(control, treatment, equal_var=True, alternative="two-sided")
+
+    return AaTestResult(
+        control_mean=control_mean,
+        treatment_mean=treatment_mean,
+        difference=difference,
+        p_value=p_value,
+        control_size=len(control),
+        treatment_size=len(treatment),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    metric = load_metric(
+        args.data_path,
+        str(args.metric_column),
+        delimiter=args.delimiter,
+        has_header=args.has_header,
+    )
+    if not metric:
+        raise ValueError("No valid observations were loaded from the dataset.")
+
+    result = run_aa_test(metric, seed=args.seed, test_size=args.test_size)
+
+    print("Control group size:", result.control_size)
+    print("Treatment group size:", result.treatment_size)
+    print("Control mean CTR:", f"{result.control_mean:.4f}")
+    print("Treatment mean CTR:", f"{result.treatment_mean:.4f}")
+    print("Difference (treatment - control):", f"{result.difference:.4f}")
+    print("Two-tailed p-value:", f"{result.p_value:.6f}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/download_criteo_sample.py
+++ b/scripts/download_criteo_sample.py
@@ -1,0 +1,67 @@
+"""Download a small sample of the public Criteo click-through-rate dataset.
+
+The script defaults to the sample hosted by the RecoHut AB testing tutorial project on GitHub.
+The file contains the first 10,000 rows of the original Kaggle dataset and is more than
+sufficient for demonstration purposes.
+
+Example usage
+-------------
+python scripts/download_criteo_sample.py \
+    --output data/raw/criteo_sample.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+from typing import Optional
+from urllib.request import urlopen
+
+DEFAULT_URL = (
+    "https://github.com/RecoHut-Projects/AB-Testing-Tutorial/raw/main/data/criteo_sampled_data.csv"
+)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="Location of the sample dataset to download.",
+    )
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("data/raw/criteo_sample.csv"),
+        help="Where to store the downloaded file.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the existing file if it already exists.",
+    )
+    return parser.parse_args(argv)
+
+
+def download(url: str, destination: pathlib.Path, overwrite: bool = False) -> pathlib.Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.exists() and not overwrite:
+        raise FileExistsError(
+            f"Destination '{destination}' already exists. Use --overwrite to replace it."
+        )
+
+    with urlopen(url) as response, destination.open("wb") as file:  # type: ignore[arg-type]
+        shutil.copyfileobj(response, file)
+    return destination
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    path = download(args.url, args.output, args.overwrite)
+    print(f"Downloaded sample dataset to {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- import `scipy.stats.ttest_ind` for the A/A test and drop the bespoke t-distribution helpers
- document the SciPy dependency in the setup instructions and describe the new implementation
- add SciPy back to the editable install requirements

## Testing
- `pip install -e .`
- `python run_aa_test.py --data-path tests/data/mock_criteo_sample.tsv --delimiter="\t" --seed 1 --test-size 0.5 --has-header`


------
https://chatgpt.com/codex/tasks/task_e_68d3547f13ec832eb8b8f500abe28b6d